### PR TITLE
New feature: Optional -c opt to set name of what command failed in email subject line

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Run `~/bin/myscript.sh` every 5 minutes for an hour, including command line opti
 
 Run `~/bin/myscript.sh` every 5 minutes for an hour, including command line options, redirect all output to a log file, and email `email.address@gmail.com` the log file if there was an error:
 
-    $ keep-trying -s 5 -t 60 -e email.address@gmail.com -l ~/myscript.log ~/bin/myscript.sh opt1 opt2
+    $ keep-trying -s 5 -t 60 -e email.address@gmail.com -l ~/myscript.log -c myscript ~/bin/myscript.sh opt1 opt2

--- a/keep-trying
+++ b/keep-trying
@@ -12,6 +12,8 @@ usage() {
   printf "  optional args:\n"
   printf "    -l LOG_FILE            redirect all output to the given log failed\n"
   printf "    -e EMAIL_ADDRESS       send email to this address when the command never succeeds\n"
+  printf "    -c COMMAND_NAME        provide a name for the command keep-trying is running, to\n"
+  printf "                           print in the email subject (default is $(basename "$0"))\n"
 }
 
 #---------------------------------------------------------------------------------------------------
@@ -20,7 +22,8 @@ usage() {
 # Defaults
 time_between_tries=0
 time_to_try=0
-while getopts ':s:t:e:l:h' option; do
+cmd_name=$(basename "$0")
+while getopts ':s:t:e:l:c:h' option; do
   case "$option" in
     s)
       time_between_tries=$OPTARG
@@ -33,6 +36,9 @@ while getopts ':s:t:e:l:h' option; do
       ;;
     e)
       email_address=$OPTARG
+      ;;
+    c)
+      cmd_name=$OPTARG
       ;;
     h)
       usage
@@ -118,10 +124,10 @@ else
     if [[ ! -z "$email_address" ]] ; then
         email_body="The following command:\n\n${command}\n\nwas unsuccessful after ${try_count} tries (${minutes_passed} minutes)\n"
         if [[ ! -z "$log_file" ]] ; then
-            echo -e "$email_body" | mutt -s "$(basename $0) unsuccessful" $email_address -a "$log_file"
+            echo -e "$email_body" | mutt -s "${cmd_name} unsuccessful" $email_address -a "$log_file"
         else
             email_body="${email_body}\n\nSee log file attached"
-            echo -e "$email_body" | mutt -s "$(basename "$0") unsuccessful" $email_address
+            echo -e "$email_body" | mutt -s "${cmd_name} unsuccessful" $email_address
         fi
     fi
 fi


### PR DESCRIPTION
Preserves original behavior if the option is not passed.

When executing:
`keep-trying -s 1 -t 1 -e mike.charles@noaa.gov false`
Email sent with subject: `keep-trying unsuccessful`

When executing:
`keep-trying -s 1 -t 1 -e mike.charles@noaa.gov -c facepunch false`
Email sent with subject: `facepunch unsuccessful`