### PR TITLE
Allow multiple email addresses in mutt commands

### DIFF
--- a/keep-trying
+++ b/keep-trying
@@ -145,14 +145,12 @@ else
                 zip -rq "${log_file}.zip" $log_file
                 log_file="${log_file}.zip"
             fi
-            #echo -e $email_body | mutt -s "$email_subject" $email_address -a "$log_file"
             echo -e $email_body | mutt -s "$email_subject" -a "$log_file" -- $email_address
             if [[ $zip_log -eq 1 ]] ; then
                 rm "$log_file"
             fi
         else
             email_body="${email_body}\n\nSee log file attached"
-            #echo -e $email_body | mutt -s "$email_subject" $email_address
             echo -e $email_body | mutt -s "$email_subject" -- $email_address
         fi
     fi

--- a/keep-trying
+++ b/keep-trying
@@ -20,6 +20,7 @@ usage() {
   printf "    -l LOG_FILE            redirect all output to the given log failed\n"
   printf "    -z                     zip the log file before attaching\n"
   printf "    -e EMAIL_ADDRESS       send email to this address when the command never succeeds\n"
+  printf "                           put multiple addresses in quotes: \"addr1@domain, addr2@domain\"\n"
   printf "    -s EMAIL_SUBJECT       specify the subject of the email sent if the command never succeeds\n"
 }
 
@@ -138,19 +139,21 @@ else
         if [[ -z "$email_subject" ]] ; then
             email_subject="$(basename $0) unsuccessful"
         fi
-        # Set sender email address
+        # Set sender email address(es)
         if [[ ! -z "$log_file" ]] ; then
             if [[ $zip_log -eq 1 ]] ; then
                 zip -rq "${log_file}.zip" $log_file
                 log_file="${log_file}.zip"
             fi
-            echo -e $email_body | mutt -s "$email_subject" $email_address -a "$log_file"
+            #echo -e $email_body | mutt -s "$email_subject" $email_address -a "$log_file"
+            echo -e $email_body | mutt -s "$email_subject" -a "$log_file" -- $email_address
             if [[ $zip_log -eq 1 ]] ; then
                 rm "$log_file"
             fi
         else
             email_body="${email_body}\n\nSee log file attached"
-            echo -e $email_body | mutt -s "$email_subject" $email_address
+            #echo -e $email_body | mutt -s "$email_subject" $email_address
+            echo -e $email_body | mutt -s "$email_subject" -- $email_address
         fi
     fi
 fi


### PR DESCRIPTION
We need the ability for keep-trying to email multiple recipients when a command fails. Here is a proposed update using a technique described [here](https://gist.github.com/narthur/52d1cd2049d4ca5af2f3)